### PR TITLE
Patch try div method for u192 decimal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "decimal"
-version = "0.5.0"
+version = "0.7.0"
 edition = "2021"
 
 [features]
 serde = ["serde_crate", "serde_json"]
 
 [dependencies]
-anchor-lang = "0.25"
+anchor-lang = "0.24.2"
 serde_json = { version = "1.0", optional = true }
 uint = "0.9"
 


### PR DESCRIPTION
Fixed a bug in `try_div` that occured whenever the scaled numerator was bigger than 1E+39 in scale while being smaller than the scaled denominator.